### PR TITLE
Problem with nested parameters in controller requests.

### DIFF
--- a/lib/riot/action_controller/http_methods.rb
+++ b/lib/riot/action_controller/http_methods.rb
@@ -8,8 +8,7 @@ module RiotRails
       def delete(uri, params={}); perform_request("DELETE", uri, params); end
     private
       def perform_request(request_method, uri, params)
-        params = params.inject({}) { |acc,(key,val)| acc[key] = val.to_s; acc }
-        @env = ::Rack::MockRequest.env_for(uri, {:params => params, :method => request_method}).merge(@env)
+        @env = ::Rack::MockRequest.env_for(uri, {:params => params.stringify_values, :method => request_method}).merge(@env)
         @env['action_dispatch.show_exceptions'] = false
         @app.call(@env).tap { |state| @response = state.last }
       end

--- a/lib/riot/core_ext.rb
+++ b/lib/riot/core_ext.rb
@@ -1,0 +1,1 @@
+require 'riot/core_ext/hash'

--- a/lib/riot/core_ext/hash.rb
+++ b/lib/riot/core_ext/hash.rb
@@ -1,0 +1,18 @@
+module RiotRails
+  module CoreExt
+    module Hash
+      def stringify_values
+        inject({}) do |hsh,(key,val)|
+          hsh[key] = val.respond_to?(:stringify_values) ? val.stringify_values : val.to_s
+          hsh
+        end
+      end
+      
+      def stringify_values!
+        replace(stringify_values)
+      end
+    end # Hash
+  end # CoreExt
+end # RiotRails
+
+Hash.class_eval { include RiotRails::CoreExt::Hash }

--- a/lib/riot/rails.rb
+++ b/lib/riot/rails.rb
@@ -1,1 +1,2 @@
+require 'riot/core_ext'
 require 'riot'

--- a/test/action_controller/post_request_test.rb
+++ b/test/action_controller/post_request_test.rb
@@ -39,6 +39,17 @@ context RoomsController do
       asserts("params") { controller.params }.includes("momma")
       asserts("params") { controller.params }.includes("love_you_too")
     end # with parameters
+    
+    context "with nested parameters" do
+      setup { post "/rooms/create", {:momma => {:loves => {:son => :yes, :daughter => :also} } } }
+      
+      asserts("params") { controller.params }.includes("momma")
+      asserts("params") { controller.params[:momma] }.includes("loves")
+      asserts("params") { controller.params[:momma][:loves] }.includes("son")
+      asserts("params") { controller.params[:momma][:loves][:son] }.equals("yes")
+      asserts("params") { controller.params[:momma][:loves] }.includes("daughter")
+      asserts("params") { controller.params[:momma][:loves][:daughter] }.equals("also")
+    end
 
   end # for a POST request
 

--- a/test/core_ext/hash_test.rb
+++ b/test/core_ext/hash_test.rb
@@ -1,0 +1,24 @@
+require 'teststrap'
+
+context "Hash#stringify_values" do
+  
+  context "a simple hash" do
+    setup { { :a => 1} }
+    asserts(:stringify_values).equals { {:a => '1'} }
+  end
+  
+  context "a nested hash" do
+    setup { { :a => { :b => :ddjkgdkj, :c => 23 }} }
+    asserts(:stringify_values).equals { {:a => { :b => 'ddjkgdkj', :c => '23' } } }
+  end
+  
+end
+
+context "Hash#stringify_values!" do
+  context "some hash" do
+    setup { { 1 => 2 } }
+    should "replace self with stringify_values'd version" do
+      topic.tap { |t| t.stringify_values! }
+    end.equals({ 1 => '2' })
+  end
+end


### PR DESCRIPTION
Hey Gus, et.al.:

As discussed here, http://github.com/thumblemonks/riot-rails/commit/3b8c23d54f1102fdfa0d8655320784f0639b5d62#commitcomment-110228 nested parameters were  being thrown away when values were converted to strings. danhodos and I added this commit to recursively convert parameter values so you can do controller testing with nested params.

Let us know what you think. Thanks!

AJ & Dan.
